### PR TITLE
fix: Reject beta versions older than the latest beta tag

### DIFF
--- a/actions/release-tag-creation/current-version-validation.test.ts
+++ b/actions/release-tag-creation/current-version-validation.test.ts
@@ -59,9 +59,16 @@ describe('checkVersionIsNext', () => {
 			['4.2.0-beta1', '4.2.0-beta2'],
 			'4.2.0-beta2',
 			false,
-			'Expected next beta to be 4.2.0-beta3',
+			'must be greater than the latest beta tag 4.2.0-beta2',
 		],
-		// beta — new version line
+		[
+			'beta',
+			['4.2.0-beta1', '4.2.0-beta2'],
+			'4.2.0-beta1',
+			false,
+			'must be greater than the latest beta tag 4.2.0-beta2',
+		],
+		// beta — new version line (must be greater than latest AND beta1)
 		['beta', ['4.2.0-beta1', '4.2.0-beta2'], '4.3.0-beta1', true, null],
 		[
 			'beta',
@@ -69,6 +76,14 @@ describe('checkVersionIsNext', () => {
 			'4.3.0-beta2',
 			false,
 			'must be beta1',
+		],
+		// beta — older version line must be rejected (regression)
+		[
+			'beta',
+			['4.2.0-beta1', '4.2.0-beta2'],
+			'4.1.0-beta1',
+			false,
+			'must be greater than the latest beta tag 4.2.0-beta2',
 		],
 		// beta — no existing tags
 		['beta', ['4.1.0', '4.2.0'], '4.2.0-beta1', true, null],

--- a/actions/release-tag-creation/current-version-validation.ts
+++ b/actions/release-tag-creation/current-version-validation.ts
@@ -48,6 +48,12 @@ function validateNextBeta(
 	l: semver.SemVer,
 	latest: string,
 ): void {
+	if (!semver.gt(n, l)) {
+		throw new Error(
+			`Version ${version} must be greater than the latest beta tag ${latest}.`,
+		);
+	}
+
 	const latestBetaNum = Number(String(l.prerelease[0]).replace('beta', ''));
 	const newBetaNum = Number(String(n.prerelease[0]).replace('beta', ''));
 	const sameLine =


### PR DESCRIPTION
## Summary
- `validateNextBeta` accepted any `*-beta1` on a different version line, including regressions like `4.1.0-beta1` after latest `4.2.0-beta2`.
- Require `semver.gt(candidate, latestBeta)` before the existing same-line / beta1 sequencing checks.
- Add regression coverage for older version lines and same-or-older betas on the latest line.

## Test plan
- [x] `npm test` in `actions/release-tag-creation` (15 passed)
- [ ] Re-run controlled-release dry-run with `4.1.0-beta1` when latest beta is `4.2.0-beta2` and confirm it fails with the new error
- [ ] Confirm valid progressions still pass: `4.2.0-beta3`, `4.3.0-beta1`

Ref: ED-24452

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Beta version validation was allowing regressions by accepting older beta versions as valid. ED-24452 adds a version comparison guard to ensure new beta releases are always greater than the latest existing beta tag.

## 2. What Changed (Where)

- `current-version-validation.ts`: Added upfront `semver.gt()` check rejecting any beta version not greater than latest beta tag
- `current-version-validation.test.ts`: Updated error message expectations and added regression test for older version line scenario

## 3. How It Works

The new validation runs first in `validateNextBeta()`, comparing the proposed version `n` against the latest beta `l` using semver. If `n` is not strictly greater, it fails immediately with a clear message before attempting subsequent beta number/line validations. This prevents acceptance of versions like `4.1.0-beta1` when `4.2.0-beta2` exists.

## 4. Risks

None identified. Change is defensive and properly tested with explicit regression case.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
