### PR TITLE
fix: check major and minor versions are tracking [ED-24551]

### DIFF
--- a/actions/release-tag-creation/current-version-validation.test.ts
+++ b/actions/release-tag-creation/current-version-validation.test.ts
@@ -61,14 +61,43 @@ describe('checkVersionIsNext', () => {
 			false,
 			'Expected next beta to be 4.2.0-beta3',
 		],
-		// beta — new version line
+		// beta — next minor / next major
 		['beta', ['4.2.0-beta1', '4.2.0-beta2'], '4.3.0-beta1', true, null],
+		['beta', ['4.2.0-beta1', '4.2.0-beta2'], '5.0.0-beta1', true, null],
 		[
 			'beta',
 			['4.2.0-beta1', '4.2.0-beta2'],
 			'4.3.0-beta2',
 			false,
-			'must be beta1',
+			'Expected next beta line to be 4.3.0-beta1 or 5.0.0-beta1',
+		],
+		[
+			'beta',
+			['4.2.0-beta1', '4.2.0-beta2'],
+			'4.4.0-beta1',
+			false,
+			'Expected next beta line to be 4.3.0-beta1 or 5.0.0-beta1',
+		],
+		[
+			'beta',
+			['4.2.0-beta1', '4.2.0-beta2'],
+			'4.1.0-beta1',
+			false,
+			'Expected next beta line to be 4.3.0-beta1 or 5.0.0-beta1',
+		],
+		[
+			'beta',
+			['4.2.0-beta1', '4.2.0-beta2'],
+			'6.0.0-beta1',
+			false,
+			'Expected next beta line to be 4.3.0-beta1 or 5.0.0-beta1',
+		],
+		[
+			'beta',
+			['4.2.0-beta1', '4.2.0-beta2'],
+			'5.1.0-beta1',
+			false,
+			'Expected next beta line to be 4.3.0-beta1 or 5.0.0-beta1',
 		],
 		// beta — no existing tags
 		['beta', ['4.1.0', '4.2.0'], '4.2.0-beta1', true, null],

--- a/actions/release-tag-creation/current-version-validation.ts
+++ b/actions/release-tag-creation/current-version-validation.ts
@@ -52,14 +52,20 @@ function validateNextBeta(
 	const newBetaNum = Number(String(n.prerelease[0]).replace('beta', ''));
 	const sameLine =
 		n.major === l.major && n.minor === l.minor && n.patch === l.patch;
-	if (sameLine && newBetaNum !== latestBetaNum + 1) {
-		throw new Error(
-			`Expected next beta to be ${latest.replace(`beta${String(latestBetaNum)}`, `beta${String(latestBetaNum + 1)}`)}, got ${version}.`,
-		);
+	if (sameLine) {
+		if (newBetaNum !== latestBetaNum + 1) {
+			throw new Error(
+				`Expected next beta to be ${latest.replace(`beta${String(latestBetaNum)}`, `beta${String(latestBetaNum + 1)}`)}, got ${version}.`,
+			);
+		}
+		return;
 	}
-	if (!sameLine && newBetaNum !== 1) {
+
+	const nextMinor = `${String(l.major)}.${String(l.minor + 1)}.0-beta1`;
+	const nextMajor = `${String(l.major + 1)}.0.0-beta1`;
+	if (version !== nextMinor && version !== nextMajor) {
 		throw new Error(
-			`First beta of a new version line must be beta1, got ${version}.`,
+			`Expected next beta line to be ${nextMinor} or ${nextMajor}, got ${version} (latest: ${latest}).`,
 		);
 	}
 }


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Beta version validation wasn't checking that major/minor versions increment correctly between release lines. ED-24551 requires stricter tracking — beta releases can only increment patch on same line, or bump to next minor/major with beta1.

## 2. What Changed (Where)

- `current-version-validation.ts`: Refactored `validateNextBeta()` to enforce next-minor (x.y+1.0-beta1) or next-major (x+1.0.0-beta1) transitions, replacing generic "must be beta1" check.
- `current-version-validation.test.ts`: Expanded test cases to cover valid transitions and rejection of invalid version jumps (4.4.0, 5.1.0, 6.0.0, etc.).

## 3. How It Works

Same-line beta increments require exact `latestBetaNum + 1` sequence. New-line transitions must be precisely `nextMinor` or `nextMajor` (both with `-beta1`); any other version string fails with clear expectation message.

## 4. Risks

Low — validation tightens constraints (should reject more invalid states, not break valid ones). Test coverage is comprehensive for edge cases.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
