### PR TITLE
fix: prerelease shows null [ED-24451]

### DIFF
--- a/actions/release-tag-creation/main.ts
+++ b/actions/release-tag-creation/main.ts
@@ -74,7 +74,7 @@ export function extractChannel(version: string): 'stable' | 'beta' {
 	const prerelease = semver.prerelease(version);
 
 	console.log(
-		`Determining channel for version "${version}" (prerelease: ${prerelease !== null})`,
+		`Determining channel for version "${version}" (prerelease: ${prerelease !== null ? String(prerelease[0]) : 'Stable'})`,
 	);
 
 	if (prerelease === null) {

--- a/actions/release-tag-creation/main.ts
+++ b/actions/release-tag-creation/main.ts
@@ -74,7 +74,7 @@ export function extractChannel(version: string): 'stable' | 'beta' {
 	const prerelease = semver.prerelease(version);
 
 	console.log(
-		`Determining channel for version "${version}" (prerelease: ${JSON.stringify(prerelease)})`,
+		`Determining channel for version "${version}" (prerelease: ${prerelease !== null})`,
 	);
 
 	if (prerelease === null) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

`JSON.stringify(prerelease)` outputs `null` for stable versions, making logs confusing. This fix explicitly handles the null case to display "Stable" instead.

## 2. What Changed (Where)

`actions/release-tag-creation/main.ts`: Console log in `extractChannel()` now conditionally stringifies prerelease array or displays "Stable".

## 3. How It Works

When `semver.prerelease()` returns null (stable version), ternary operator outputs "Stable"; otherwise converts array element to string.

## 4. Risks

None—log-only change with improved clarity.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
