### PR TITLE
feat: add shared invalidate-changelog-cache composite action [ED-25349]

### DIFF
--- a/actions/invalidate-changelog-cache/action.yml
+++ b/actions/invalidate-changelog-cache/action.yml
@@ -2,61 +2,61 @@ name: Invalidate changelog cache
 description: Bust Elementor.com product changelog transients after a release.
 
 inputs:
-  invalidate_token:
-    description: 'API key sent as api-key header; Hosting WAF validates it.'
-    required: true
-  product:
-    description: 'Changelog product: core or pro.'
-    required: true
-  channel:
-    description: 'Release channel: ga, stable, or beta. Ignored when types is set.'
-    required: false
-    default: ''
-  types:
-    description: 'Optional space-separated changelog types (release, beta, dev). Overrides channel mapping.'
-    required: false
-    default: ''
+    invalidate_token:
+        description: 'API key sent as api-key header; Hosting WAF validates it.'
+        required: true
+    product:
+        description: 'Changelog product: core or pro.'
+        required: true
+    channel:
+        description: 'Release channel: ga, stable, or beta. Ignored when types is set.'
+        required: false
+        default: ''
+    types:
+        description: 'Optional space-separated changelog types (release, beta, dev). Overrides channel mapping.'
+        required: false
+        default: ''
 
 runs:
-  using: "composite"
-  steps:
-    - name: Invalidate changelog cache
-      shell: bash
-      env:
-        INVALIDATE_TOKEN: ${{ inputs.invalidate_token }}
-        PRODUCT: ${{ inputs.product }}
-        CHANNEL: ${{ inputs.channel }}
-        TYPES_INPUT: ${{ inputs.types }}
-        INVALIDATE_URL: https://elementor.com/wp-json/elementor-site-product-changelog/v1/cache/invalidate
-      run: |
-        set -euo pipefail
+    using: 'composite'
+    steps:
+        - name: Invalidate changelog cache
+          shell: bash
+          env:
+              INVALIDATE_TOKEN: ${{ inputs.invalidate_token }}
+              PRODUCT: ${{ inputs.product }}
+              CHANNEL: ${{ inputs.channel }}
+              TYPES_INPUT: ${{ inputs.types }}
+              INVALIDATE_URL: https://elementor.com/wp-json/elementor-site-product-changelog/v1/cache/invalidate
+          run: |
+              set -euo pipefail
 
-        if [ -z "${INVALIDATE_TOKEN}" ]; then
-          echo "Changelog cache invalidate token is not configured. Skipping."
-          exit 0
-        fi
+              if [ -z "${INVALIDATE_TOKEN}" ]; then
+                echo "Changelog cache invalidate token is not configured. Skipping."
+                exit 0
+              fi
 
-        if [ -n "${TYPES_INPUT}" ]; then
-          TYPES="${TYPES_INPUT}"
-        else
-          case "${CHANNEL}" in
-            ga|stable) TYPES="release" ;;
-            beta) TYPES="beta dev" ;;
-            dev) TYPES="dev" ;;
-            *)
-              echo "Unknown channel '${CHANNEL}', skipping changelog cache invalidation."
-              exit 0
-              ;;
-          esac
-        fi
+              if [ -n "${TYPES_INPUT}" ]; then
+                TYPES="${TYPES_INPUT}"
+              else
+                case "${CHANNEL}" in
+                  ga|stable) TYPES="release" ;;
+                  beta) TYPES="beta dev" ;;
+                  dev) TYPES="dev" ;;
+                  *)
+                    echo "Unknown channel '${CHANNEL}', skipping changelog cache invalidation."
+                    exit 0
+                    ;;
+                esac
+              fi
 
-        for TYPE in ${TYPES}; do
-          echo "Invalidating changelog cache product=${PRODUCT} type=${TYPE}"
-          if ! curl --fail --show-error --silent --max-time 60 --request POST \
-            --header "Content-Type: application/json" \
-            --header "api-key: ${INVALIDATE_TOKEN}" \
-            --data "{\"product\":\"${PRODUCT}\",\"type\":\"${TYPE}\"}" \
-            "${INVALIDATE_URL}"; then
-            echo "Warning: failed to invalidate changelog cache type=${TYPE}"
-          fi
-        done
+              for TYPE in ${TYPES}; do
+                echo "Invalidating changelog cache product=${PRODUCT} type=${TYPE}"
+                if ! curl --fail --show-error --silent --max-time 60 --request POST \
+                  --header "Content-Type: application/json" \
+                  --header "api-key: ${INVALIDATE_TOKEN}" \
+                  --data "{\"product\":\"${PRODUCT}\",\"type\":\"${TYPE}\"}" \
+                  "${INVALIDATE_URL}"; then
+                  echo "Warning: failed to invalidate changelog cache type=${TYPE}"
+                fi
+              done

--- a/actions/invalidate-changelog-cache/action.yml
+++ b/actions/invalidate-changelog-cache/action.yml
@@ -1,0 +1,62 @@
+name: Invalidate changelog cache
+description: Bust Elementor.com product changelog transients after a release.
+
+inputs:
+  invalidate_token:
+    description: 'API key sent as api-key header; Hosting WAF validates it.'
+    required: true
+  product:
+    description: 'Changelog product: core or pro.'
+    required: true
+  channel:
+    description: 'Release channel: ga, stable, or beta. Ignored when types is set.'
+    required: false
+    default: ''
+  types:
+    description: 'Optional space-separated changelog types (release, beta, dev). Overrides channel mapping.'
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - name: Invalidate changelog cache
+      shell: bash
+      env:
+        INVALIDATE_TOKEN: ${{ inputs.invalidate_token }}
+        PRODUCT: ${{ inputs.product }}
+        CHANNEL: ${{ inputs.channel }}
+        TYPES_INPUT: ${{ inputs.types }}
+        INVALIDATE_URL: https://elementor.com/wp-json/elementor-site-product-changelog/v1/cache/invalidate
+      run: |
+        set -euo pipefail
+
+        if [ -z "${INVALIDATE_TOKEN}" ]; then
+          echo "Changelog cache invalidate token is not configured. Skipping."
+          exit 0
+        fi
+
+        if [ -n "${TYPES_INPUT}" ]; then
+          TYPES="${TYPES_INPUT}"
+        else
+          case "${CHANNEL}" in
+            ga|stable) TYPES="release" ;;
+            beta) TYPES="beta dev" ;;
+            dev) TYPES="dev" ;;
+            *)
+              echo "Unknown channel '${CHANNEL}', skipping changelog cache invalidation."
+              exit 0
+              ;;
+          esac
+        fi
+
+        for TYPE in ${TYPES}; do
+          echo "Invalidating changelog cache product=${PRODUCT} type=${TYPE}"
+          if ! curl --fail --show-error --silent --max-time 60 --request POST \
+            --header "Content-Type: application/json" \
+            --header "api-key: ${INVALIDATE_TOKEN}" \
+            --data "{\"product\":\"${PRODUCT}\",\"type\":\"${TYPE}\"}" \
+            "${INVALIDATE_URL}"; then
+            echo "Warning: failed to invalidate changelog cache type=${TYPE}"
+          fi
+        done


### PR DESCRIPTION
## Jira

https://elementor.atlassian.net/browse/ED-25349

## Summary

- Adds `actions/invalidate-changelog-cache`, a composite action that POSTs to the marketing-plugins cache invalidate endpoint after a release.
- Endpoint URL is hardcoded: `https://elementor.com/wp-json/elementor-site-product-changelog/v1/cache/invalidate`
- Workflows pass `api-key` from repo secret `ELEMENTOR_SITE_CHANGELOG_CACHE_INVALIDATE_API_KEY` (WAF validation, same pattern as GlotPress `import-originals`).
- Supports explicit `types` input for split beta/dev invalidation, `curl --max-time 60`, and per-type failure tolerance.
- No-ops when the token secret is empty.

## Consumers

- elementor/elementor#37036 — Core one-click + controlled release
- elementor/elementor-pro#7508 — Pro one-click release

Merge this first; consumer PRs reference `@main`.

## Secret setup

Set **`ELEMENTOR_SITE_CHANGELOG_CACHE_INVALIDATE_API_KEY`** in `elementor/elementor` and `elementor/elementor-pro`.

## Test plan

- [ ] Merge and confirm `@main` resolves.
- [ ] Set the API key secret to the WAF token value.
- [ ] Run a release workflow and confirm successful POSTs with `api-key` header.
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Implements a shared GitHub composite action to automate the busting of Elementor.com product changelog transients after releases (ED-25349).

## 2. What Changed (Where)
- `actions/invalidate-changelog-cache/action.yml`: New composite action definition and bash implementation.

## 3. How It Works
The action takes a product and channel/type, maps the channel to a changelog type, and iterates through them to send POST requests to the invalidation API.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
